### PR TITLE
HID strings

### DIFF
--- a/iidx-controller/IIDXHID.h
+++ b/iidx-controller/IIDXHID.h
@@ -7,6 +7,7 @@
 #define NO_SENSITIVITY 0
 
 #define EPTYPE_DESCRIPTOR_SIZE uint8_t
+#define STRING_ID_Base 4
 
 class IIDXHID_ : public PluggableUSBModule {
     public:


### PR DESCRIPTION
This allows the controller to appear as "gladuin IIDX controller" in spicecfg and btools, and having named outputs as well :

![image](https://user-images.githubusercontent.com/36906596/124387192-de46d800-dcdd-11eb-872f-c40b48e9c8f9.png)

Note: this way of declaring the descriptors with string minimum and maximum doesn't play well with btools for some reason (only tt sensitivity appears correctly there), but this should be valid so I think btools should be patched instead...

I haven't double-checked if lights were in correct order on the base code since I'm running a modded version for my controller, but I think it should work fine