### PR TITLE
konami spoof

### DIFF
--- a/iidx-controller/IIDXHID.h
+++ b/iidx-controller/IIDXHID.h
@@ -6,6 +6,8 @@
 
 #define NO_SENSITIVITY 0
 
+#define KONAMI_SPOOF 1
+
 #define EPTYPE_DESCRIPTOR_SIZE uint8_t
 #define STRING_ID_Base 4
 
@@ -22,7 +24,6 @@ class IIDXHID_ : public PluggableUSBModule {
 
         int getInterface(uint8_t* interface_count);
         int getDescriptor(USBSetup& setup);
-        uint8_t getShortName(char* name);
         bool setup(USBSetup& setup);
 };
 


### PR DESCRIPTION
Hi,
I've found a way to set custom VID/PID from code without any change to the board file or core files :)

I've put this behind a KONAMI_SPOOF option in case you want to disable it (the only drawback I can think of is issues for people with a real konami controller and another custom controller running this code on the same pc, as keeping the same vid/pid might mess with windows hid cache...)

Note that I've changed the device type from Gamepad to Joystick in the HID descriptor as this is needed for compatibility with Infinitas/UM, this shouldn't change anything for windows

I've also gotten rid of the getShortName() which was made to set the serial hid string (since we're already setting custom strings for manufacturer etc, I think it's cleaner to keep the same mechanics for serial as well)