### PR TITLE
Updates to encoder logic, minor cleanup

### DIFF
--- a/iidx-controller/IIDXHID.cpp
+++ b/iidx-controller/IIDXHID.cpp
@@ -1,8 +1,8 @@
 #include "IIDXHID.h"
 #include "config.h"
 
-#define BUTTON_PADDING (8 - (sizeof(button_pins) % 8))
-#define LED_PADDING (8 - (sizeof(led_pins) % 8))
+#define BUTTON_PADDING (8 - (NUM_BUTTONS % 8))
+#define LED_PADDING (8 - (NUM_LEDS % 8))
 
 #define ENCODERMAX1 ADJUSTED_PPR & 0x00FF
 #define ENCODERMAX2 ADJUSTED_PPR >> 8
@@ -71,11 +71,11 @@ static const uint8_t PROGMEM hid_report[] = {
     /* Buttons */
     0x05, 0x09,                      //   USAGE_PAGE (Button)
     0x19, 0x01,                      //   USAGE_MINIMUM (Button 1)
-    0x29, sizeof(button_pins),       //   USAGE_MAXIMUM (Button sizeof(button_pins))
+    0x29, NUM_BUTTONS,               //   USAGE_MAXIMUM (Button sizeof(button_pins))
     0x15, 0x00,                      //   LOGICAL_MINIMUM (0)
     0x25, 0x01,                      //   LOGICAL_MAXIMUM (1)
     0x75, 0x01,                      //   REPORT_SIZE (1)
-    0x95, sizeof(button_pins),       //   REPORT_COUNT (sizeof(button_pins))
+    0x95, NUM_BUTTONS,               //   REPORT_COUNT (sizeof(button_pins))
     0x55, 0x00,                      //   UNIT_EXPONENT (0)
     0x65, 0x00,                      //   UNIT (None)
     0x81, 0x02,                      //   INPUT (Data,Var,Abs)
@@ -122,7 +122,7 @@ static const uint8_t PROGMEM hid_report[] = {
     0x15, 0x00,                      //   LOGICAL_MINIMUM (0)
     0x25, 0x01,                      //   LOGICAL_MAXIMUM (1)
     0x75, 0x01,                      //   REPORT_SIZE (1)
-    0x95, sizeof(led_pins),          //   REPORT_COUNT (sizeof(led_pins))
+    0x95, NUM_LEDS,                  //   REPORT_COUNT (sizeof(led_pins))
     0xa1, 0x02,                      //   COLLECTION (Logical)
     0x89, 0x04,                      //     STRING_MINIMUM (4)
     0x99, 0x0e,                      //     STRING_MAXIMUM (14)

--- a/iidx-controller/IIDXHID.h
+++ b/iidx-controller/IIDXHID.h
@@ -1,3 +1,6 @@
+#ifndef __IIDXHID_h
+#define __IIDXHID_h
+
 #include "HID.h"
 
 #define ADJUSTED_PPR ((int)((float)ENCODER_PPR * ((float)255 / (float)INCREMENTS_PER_FULL_TURN)))
@@ -19,3 +22,5 @@ class IIDXHID_ : public PluggableUSBModule {
 };
 
 extern IIDXHID_ IIDXHID;
+
+#endif

--- a/iidx-controller/config.h
+++ b/iidx-controller/config.h
@@ -1,3 +1,6 @@
+#ifndef __CONFIG_h
+#define __CONFIG_h
+
 /* PINOUT */
 // Pins where the LEDs are connected to
 const uint8_t led_pins[] = {
@@ -61,11 +64,17 @@ const uint8_t encoder_pin1 = 1;  // white wire (b phase)
 #define READFAST 1
 
 // This is (cpu_clock_frequency / prescaler / desired_interrupt_frequency)
-// for example, set to 133 for 0.5ms (2kHz)  on a 16MHz processor: (16000000L / 64 / 2000  -> 133)
-// for example, set to 50  for 0.2ms (5kHz)  on a 16MHz processor: (16000000L / 64 / 5000  -> 50)
-// for example, set to 25  for 0.1ms (10kHz) on a 16MHz processor: (16000000L / 64 / 10000 -> 25)
+// set to 133 for 0.5ms (2kHz)  on a 16MHz processor: (16000000L / 64 / 2000  -> 133)
+// set to 50  for 0.2ms (5kHz)  on a 16MHz processor: (16000000L / 64 / 5000  -> 50)
+// set to 25  for 0.1ms (10kHz) on a 16MHz processor: (16000000L / 64 / 10000 -> 25)
+// set to 12  for 0.05ms (20kHz) on a 16MHz processor: (16000000L / 64 / 20833 -> 12)
+#if ENCODER_PPR < 360
 #define INTERRUPT_PERIOD 25
+#else // High PPR encoders have the possibility to switch faster than the timer
+#define INTERRUPT_PERIOD 12
+#endif
 
+/* DEFINES FOR ELSEWHERE IN THE CODE, DO NOT MODIFY LINES BELOW THIS POINT */
 #if READFAST == 1
     #include "digitalWriteFast.h"
     #define IO_WRITE(X, Y) digitalWriteFast(X, Y)
@@ -75,4 +84,9 @@ const uint8_t encoder_pin1 = 1;  // white wire (b phase)
     #define IO_WRITE(X, Y) digitalWrite(X, Y)
     #define IO_READ(X) digitalRead(X)
     #define IO_MODE(X, Y) pinMode(X, Y)
+#endif
+
+#define NUM_BUTTONS (sizeof(button_pins) / sizeof(uint8_t))
+#define NUM_LEDS (sizeof(led_pins) / sizeof(uint8_t))
+
 #endif


### PR DESCRIPTION
Summary:
Changed encoder logic to handle multiple state changes (vs. just one).
Increases encoder timer for encoder >= 360 PPR.
Added header guards.
Added calculated defines for number of buttons and LEDs.

This should handle 600 PPR encoders better. I'm still getting skips when I spin it very fast, but I don't think that's realistic during play.