### PR TITLE
Konami spoof (Infinitas/UM support)

### DIFF
--- a/config-tool/config-tool.py
+++ b/config-tool/config-tool.py
@@ -9,6 +9,9 @@ from pywinusb import hid
 
 def get_filtered_devices():
     filter = hid.HidDeviceFilter(vendor_id = 0x0001, product_id = 0x0001)
+    # might be in konami spoof mode
+    if len(filter.get_devices()) == 0:
+        filter = hid.HidDeviceFilter(vendor_id = 0x1ccf, product_id = 0x8086)
     return filter.get_devices()
 
 def send(data):

--- a/iidx-controller/config.h
+++ b/iidx-controller/config.h
@@ -39,7 +39,23 @@
     /* OPTIONS */
     // Your encoder pulses per rotation
     #define ENCODER_PPR 600
+    
+    // Spoof the konami premium controller (UM/Infinitas compatibility)
+    #define KONAMI_SPOOF 1
+    
+    #if KONAMI_SPOOF == 0
+    // The desired VID and PID for this controller
+        #define VID 0x0001
+        #define PID 0x0001
+    // The desired manufacturer and product name of this controller (leave the L in front of the ")
+        #define MF_NAME L"username"
+        #define PROD_NAME L"IIDX Controller"
+    #else
+    // These values should not be modified as they are required for the konami spoof mode
+        #define VID 0x1ccf
+        #define PID 0x8086
+        #define MF_NAME L"Konami Amusement"
+        #define PROD_NAME L"beatmania IIDX controller premium model"  
+    #endif
 
-    // The manufacturer name of this controller (leave the L in front of the ")
-    #define MF_NAME L"username"
 #endif

--- a/iidx-controller/config.h
+++ b/iidx-controller/config.h
@@ -33,8 +33,8 @@
     };
 
     // Pins where the encoder is connected to
-    static const uint8_t encoder_pin0 = 0;  // green wire (a phase)
-    static const uint8_t encoder_pin1 = 1;  // white wire (b phase)
+    #define ENCODER_PIN_A 0 // green wire (a phase)
+    #define ENCODER_PIN_B 1 // white wire (b phase)
 
     /* OPTIONS */
     // Your encoder pulses per rotation
@@ -44,18 +44,20 @@
     #define KONAMI_SPOOF 1
     
     #if KONAMI_SPOOF == 0
-    // The desired VID and PID for this controller
         #define VID 0x0001
         #define PID 0x0001
-    // The desired manufacturer and product name of this controller (leave the L in front of the ")
+    // The manufacturer name of this controller (leave the L in front of the ")
         #define MF_NAME L"username"
         #define PROD_NAME L"IIDX Controller"
+        static const uint8_t encoder_pin0 = ENCODER_PIN_A;
+        static const uint8_t encoder_pin1 = ENCODER_PIN_B;
     #else
-    // These values should not be modified as they are required for the konami spoof mode
         #define VID 0x1ccf
         #define PID 0x8086
         #define MF_NAME L"Konami Amusement"
-        #define PROD_NAME L"beatmania IIDX controller premium model"  
+        #define PROD_NAME L"beatmania IIDX controller premium model"
+        static const uint8_t encoder_pin0 = ENCODER_PIN_B;
+        static const uint8_t encoder_pin1 = ENCODER_PIN_A;  
     #endif
 
 #endif

--- a/iidx-controller/src/HID/Descriptors.c
+++ b/iidx-controller/src/HID/Descriptors.c
@@ -186,8 +186,8 @@ const USB_Descriptor_Device_t PROGMEM device_descriptor = {
 
     .Endpoint0Size          = FIXED_CONTROL_ENDPOINT_SIZE,
 
-    .VendorID               = 0x0001,
-    .ProductID              = 0x0001,
+    .VendorID               = VID,
+    .ProductID              = PID,
     .ReleaseNumber          = VERSION_BCD(0,0,1),
 
     .ManufacturerStrIndex   = STRING_ID_Manufacturer,
@@ -329,7 +329,7 @@ USB_descriptor_configuration_struct configuration_descriptor = {
 
 const USB_Descriptor_String_t PROGMEM language_string = USB_STRING_DESCRIPTOR_ARRAY(LANGUAGE_ID_ENG);
 const USB_Descriptor_String_t PROGMEM manufacturer_string = USB_STRING_DESCRIPTOR(MF_NAME);
-const USB_Descriptor_String_t PROGMEM product_string = USB_STRING_DESCRIPTOR(L"IIDX Controller");
+const USB_Descriptor_String_t PROGMEM product_string = USB_STRING_DESCRIPTOR(PROD_NAME);
 
 const USB_Descriptor_String_t PROGMEM
     LEDString_00 = USB_STRING_DESCRIPTOR(L"Button 1"),

--- a/iidx-controller/src/HID/Descriptors.c
+++ b/iidx-controller/src/HID/Descriptors.c
@@ -82,7 +82,7 @@ USB_Descriptor_HIDReport_Datatype_t joystick_report[] = {
         HID_RI_REPORT_SIZE(8, 16),
         HID_RI_REPORT_COUNT(8, 1),
         HID_RI_COLLECTION(8, 0),
-            HID_RI_USAGE(8, 49),
+            HID_RI_USAGE(8, 48),
             HID_RI_INPUT(8, HID_IOF_DATA | HID_IOF_VARIABLE | HID_IOF_ABSOLUTE),
         HID_RI_END_COLLECTION(0),
 


### PR DESCRIPTION
hi again :) I ported the konami spoof code to your new codebase

Confirmed working on UM (android), so it should be ok with Infinitas..

I had to change the gamepad descriptor so that the TT axis is X instead of Y, not sure if Y was needed or if that "49" was a typo... worst case we should be able to adapt the value according to spoof mode...

I couldn't test the config tool as I was on linux and you use pywinusb but it "should work" i guess...

Nice work on the rewrite btw, LUFA rocks :)