### PR TITLE
Encoder fix + PID fix

### DIFF
--- a/config-tool/config-tool.py
+++ b/config-tool/config-tool.py
@@ -11,7 +11,7 @@ def get_filtered_devices():
     filter = hid.HidDeviceFilter(vendor_id = 0x0001, product_id = 0x0001)
     # might be in konami spoof mode
     if len(filter.get_devices()) == 0:
-        filter = hid.HidDeviceFilter(vendor_id = 0x1ccf, product_id = 0x8086)
+        filter = hid.HidDeviceFilter(vendor_id = 0x1ccf, product_id = 0x8048)
     return filter.get_devices()
 
 def send(data):

--- a/iidx-controller/config.h
+++ b/iidx-controller/config.h
@@ -53,7 +53,7 @@
         static const uint8_t encoder_pin1 = ENCODER_PIN_B;
     #else
         #define VID 0x1ccf
-        #define PID 0x8086
+        #define PID 0x8048
         #define MF_NAME L"Konami Amusement"
         #define PROD_NAME L"beatmania IIDX controller premium model"
         static const uint8_t encoder_pin0 = ENCODER_PIN_B;

--- a/iidx-controller/src/Configuration.h
+++ b/iidx-controller/src/Configuration.h
@@ -15,7 +15,8 @@
     } configuration_struct;
 
     // Macros
-    #define ADJUSTED_PPR ((int)((float)ENCODER_PPR * ((float)255 / (float)config->increments_per_full_turn)))
+    #define PPR_SCALE (255.0f / (float)ENCODER_PPR)
+    #define INCREMENT_SCALE ((float)config->increments_per_full_turn / (float)ENCODER_PPR)
     #define NUM_BUTTONS (sizeof(button_pins) / sizeof(uint8_t))
     #define NUM_LEDS (sizeof(led_pins) / sizeof(uint8_t))
 

--- a/iidx-controller/src/HID/Descriptors.c
+++ b/iidx-controller/src/HID/Descriptors.c
@@ -374,8 +374,8 @@ uint16_t CALLBACK_USB_GetDescriptor(const uint16_t wValue,
     uint16_t    size    = NO_DESCRIPTOR;
 
     // adjust logical maximum of encoder
-    joystick_report[41] = ADJUSTED_PPR & 0xFF;
-    joystick_report[42] = ADJUSTED_PPR >> 8;
+    joystick_report[41] = 0xFF;
+    joystick_report[42] = 0;
 
     // adjust min max of mouse report
     mouse_report[17] = (-ENCODER_PPR / 2) & 0xFF;

--- a/iidx-controller/src/HID/IIDXHID.c
+++ b/iidx-controller/src/HID/IIDXHID.c
@@ -201,11 +201,15 @@ void create_joystick_report(input_data_struct_joystick* input_data) {
     }
 
     if (config->tt_mode == 0) {
-        input_data->turntable_position = get_encoder_state();
+        if (config->increments_per_full_turn == 255) {
+            input_data->turntable_position = get_encoder_state();
+        } else {
+            input_data->turntable_position = get_encoder_virtual_state();
+        }
     } else if ((config->tt_mode == 2) || (config->tt_mode == 3)) {
         switch (get_digital_encoder_state()) {
             case 1:
-                if (config->tt_mode == 2) input_data->turntable_position = ADJUSTED_PPR;
+                if (config->tt_mode == 2) input_data->turntable_position = 0xFF;
                 if (config->tt_mode == 3) input_data->button_status = input_data->button_status | 0b0000100000000000;
                 break;
 
@@ -215,7 +219,7 @@ void create_joystick_report(input_data_struct_joystick* input_data) {
                 break;
 
             default:
-                if (config->tt_mode == 2) input_data->turntable_position = ADJUSTED_PPR / 2;
+                if (config->tt_mode == 2) input_data->turntable_position = 0xFF / 2;
         }
     }
 }

--- a/iidx-controller/src/IO/Encoder.h
+++ b/iidx-controller/src/IO/Encoder.h
@@ -11,6 +11,7 @@
     EXTERNC void initialise_encoder();
     EXTERNC uint8_t get_digital_encoder_state();
     EXTERNC uint16_t get_encoder_state();
+    EXTERNC uint16_t get_encoder_virtual_state();
 
     #undef EXTERNC
 


### PR DESCRIPTION
This PR is twofold:

1. The "increments per full turn" did not actually do that, so I rewrote a new function that did. I also forced the report descriptor for analog to always be 0-255 instead of 0-ADJUSTED_PPR. The downside is potential resolution loss for high PPR encoders, but in all honesty I don't think it matters. Maybe worth a revisit after some more play testing, but in casual testing it seems fine.

2. The PID for the spoof was wrong, so I fixed that. It's tested in both Infinitas and UM.